### PR TITLE
Fix formatting in the behavioral.md file

### DIFF
--- a/non-technical/behavioral.md
+++ b/non-technical/behavioral.md
@@ -19,8 +19,8 @@ Learn the [STAR](https://en.wikipedia.org/wiki/Situation,_task,_action,_result) 
 - What was the most difficult bug that you fixed in the past 6 months?
 - How do you tackle challenges? Name a difficult challenge you faced while working on a project, how you overcame it, and what you learned.
 - What are you excited about?
-– Imagine it is your first day here at the company. What do you want to work on? What features would you improve on?
-– What are the most interesting projects you have worked on and how might they be relevant to the this company's environment?
+- Imagine it is your first day here at the company. What do you want to work on? What features would you improve on?
+- What are the most interesting projects you have worked on and how might they be relevant to the this company's environment?
 - Tell me about a time you had a disagreement with your manager.
 - Talk about a project you are most passionate about, or one where you did your best work.
 - What does your best day of work look like?


### PR DESCRIPTION
The `behavioral.md` file uses `–` instead of `-` on two lines, resulting in slightly broken formatting.