### PR TITLE
Flesh out glossary, add references, convert links to md, add transpil…

### DIFF
--- a/front-end/javascript.md
+++ b/front-end/javascript.md
@@ -12,25 +12,26 @@ WIP.
 
 ## Glossary
 
-- **Closure** - TBD
+- **Closure** - "Closure is when a function is able to remember and access its lexical scope even when that function is executing outside its lexical scope." - [YDKJS](https://github.com/getify/You-Dont-Know-JS/blob/master/scope%20%26%20closures/ch5.md)
 - **Event Loop** - The event loop is a single-threaded loop that monitors the call stack and checks if there is any work to be done in the message queue. If the call stack is empty and there are callback functions in the message queue, a message is dequeued and pushed onto the call stack to be executed.
-- **Hoisting** - TBD
-- **Promise** - TBD
+- **Hoisting** - "Wherever a var appears inside a scope, that declaration is taken to belong to the entire scope and accessible everywhere throughout." - [YDKJS](https://github.com/getify/You-Dont-Know-JS/blob/master/up%20%26%20going/ch2.md#hoisting)
+- **Promise** - "The Promise object represents the eventual completion (or failure) of an asynchronous operation, and its resulting value." - [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
+  - Promises can contain an immediate value.
 - **Prototype** - TBD
-- **This** - The `this` keyword does not refer to the function in which it is used or it's scope. It refers to the object on which a function is being executed and depends entirely on the call-site of the function.
+- **This** - The `this` keyword does not refer to the function in which `this` is used or that function's scope. Javascript uses [4 rules](https://github.com/getify/You-Dont-Know-JS/blob/master/this%20%26%20object%20prototypes/ch2.md#determining-this) to determine if `this` will reference an arbitrary object, *undefined* or the *global* object inside a particular function call.
 
 ## Core Language
 
 ### Variables
 
-- https://github.com/getify/You-Dont-Know-JS/blob/master/types%20&%20grammar/README.md#you-dont-know-js-types--grammar
+- Reference: [Types and Grammar](https://github.com/getify/You-Dont-Know-JS/blob/master/types%20%26%20grammar/ch1.md)
 - Types
 - Scopes
-- Coercion
+- [Coercion](https://github.com/getify/You-Dont-Know-JS/blob/master/up%20%26%20going/ch2.md#coercion)
 
 ### Functions
 
-- https://github.com/getify/You-Dont-Know-JS/blob/master/scope%20&%20closures/README.md#you-dont-know-js-scope--closures
+- Reference: [this & Object Prototypes](https://github.com/getify/You-Dont-Know-JS/blob/master/scope%20%26%20closures/ch3.md)
 - Declaration vs Expression
 - Closures
 - `.call`, `.apply` and `.bind`
@@ -39,7 +40,7 @@ WIP.
 
 ### Prototypes and Objects
 
-- Reference: https://github.com/getify/You-Dont-Know-JS/blob/master/this%20%26%20object%20prototypes/README.md
+- Reference: [this & Object Prototypes](https://github.com/getify/You-Dont-Know-JS/blob/master/scope%20&%20closures/README.md#you-dont-know-js-scope--closures)
 - Prototype chain
 - `this` keyword
   - https://rainsoft.io/gentle-explanation-of-this-in-javascript/
@@ -50,16 +51,16 @@ WIP.
 
 ### Async
 
-- Reference: https://github.com/getify/You-Dont-Know-JS/blob/master/async%20&%20performance/README.md#you-dont-know-js-async--performance
-- `setTimeout` and `setInterval`
+- Reference: [Async and Peformance](https://github.com/getify/You-Dont-Know-JS/blob/master/async%20&%20performance/README.md#you-dont-know-js-async--performance)
+- `setTimeout`, `setInterval` and event loop
+  - [setImmediate() vs nextTick() vs setTimeout(fn,0)](http://voidcanvas.com/setimmediate-vs-nexttick-vs-settimeout/)
 - Event Loop
-  -
 - Debounce and Throttle
   - Throttling enforces a maximum number of times a function can be called over time.
   - Debouncing enforces that a function not be called again until a certain amount of time has passed without it being called.
   - https://css-tricks.com/debouncing-throttling-explained-examples/
 - Callbacks
-- Promises
+- [Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
 
 **Reference**
 
@@ -96,7 +97,11 @@ WIP.
 - First, in strict mode a short list of identifiers become reserved keywords. These words are `implements`, `interface`, `let`, `package`, `private`, `protected`, `public`, `static`, and `yield`. In strict mode, then, you can't name or use variables or arguments with these names.
 - Second, strict mode prohibits function statements not at the top level of a script or function.
 
+## Transpilation: TBD
+
 ## Useful Links
 
 - https://medium.com/javascript-scene/10-interview-questions-every-javascript-developer-should-know-6fa6bdf5ad95#.l2n8icwl4
 - https://github.com/mbeaudru/modern-js-cheatsheet
+- [Functional Programming in Javascript - Javascript Allonge](https://leanpub.com/javascriptallongesix/read)
+- [Dr. Frisby's Mostly Adequate Guide to Functional Programming](https://drboolean.gitbooks.io/mostly-adequate-guide/content/)


### PR DESCRIPTION
Flesh out glossary, add references, convert links to md, add transpilation and fp info.

I know this was in progress and there's some duplication, but I didn't want to change the structure too much. I made some of the links more specific when possible. I added some FP links to the bottom since I saw currying listed as a topic above. Also put in a transpilation topic which you may or may not want - a lot of modern front-end deals with tranpilation of some sort.