### PR TITLE
Removed 'the' in jsonp answer.

### DIFF
--- a/front-end/interview-questions.md
+++ b/front-end/interview-questions.md
@@ -891,7 +891,7 @@ The `XMLHttpRequest` API is frequently used for the asynchronous communication o
 
 JSONP (JSON with Padding) is a method commonly used to bypass the cross-domain policies in web browsers because Ajax requests from the current page to a cross-origin domain is not allowed.
 
-JSONP works by making a request to a cross-origin domain via a `<script>` tag and usually with a `callback` query parameter, for example: `https://example.com?callback=printData`. The server will then wrap the data within the a function called `printData` and return it to the client.
+JSONP works by making a request to a cross-origin domain via a `<script>` tag and usually with a `callback` query parameter, for example: `https://example.com?callback=printData`. The server will then wrap the data within a function called `printData` and return it to the client.
 
 ```html
 <!-- https://mydomain.com -->


### PR DESCRIPTION
Awesome guide. Just removed a small typo with 'the' and 'a' in the JSONP answer. 