### PR TITLE
Add references to compensation data

### DIFF
--- a/contents/understanding-compensation.md
+++ b/contents/understanding-compensation.md
@@ -5,7 +5,7 @@ title: Understanding Compensation
 
 Compensation is a huge factor when it comes to deciding between job offers. This section gives you a breakdown of the common components of compensation in the tech industry.
 
-In most companies, your compensation will consist of base salary, a performance bonus and equity/stocks.
+In most companies, your compensation will consist of base salary, a performance bonus and equity/stocks. For compensation data, check out [Levels.fyi](https://www.levels.fyi/comp.html).
 
 ### Base salary
 


### PR DESCRIPTION
Disclosure: I'm one of the makers of Levels.fyi.

This is obviously a big red flag that I'm adding a reference to a site I have an interest in. I think the community would find our data useful and more accurate than alternatives. A quick search on Google would bring up that folks regularly consult data on our site over say Glassdoor, etc.