### PR TITLE
fix typo!

### DIFF
--- a/contents/best-practice-questions.md
+++ b/contents/best-practice-questions.md
@@ -5,7 +5,7 @@ title: Best Practice Questions
 
 Here is a suggested schedule for revising and practicing algorithm questions on [LeetCode](https://leetcode.com). Sign up for an account if you don't already have one, it's critical to your success in interviewing!
 
-When practicing, you are advised to treat it like a real coding interview and check through thoroughly before submitting. Consider even manually coming up with some tests cases and running through them to verify correctness!
+When practicing, you are advised to treat it like a real coding interview and check through thoroughly before submitting. Consider even manually coming up with some test cases and running through them to verify correctness!
 
 ## Week 1 - Sequences
 


### PR DESCRIPTION
based on [this link](https://www.wordhippo.com/what-is/the-plural-of/test_case.html#targetText=The%20plural%20form%20of%20test%20case%20is%20test%20cases.), plural form of "test case" is "test cases".