### PR TITLE
contents: std::map is not a hash-table

### DIFF
--- a/contents/algorithms/hash-table.md
+++ b/contents/algorithms/hash-table.md
@@ -38,7 +38,7 @@ In the case of hash collisions, there are a number of collision resolution techn
 
 | Language | API |
 | --- | --- |
-| C++ | [`std::map`](https://docs.microsoft.com/en-us/cpp/standard-library/map) |
+| C++ | [`std::unordered_map`](https://docs.microsoft.com/en-us/cpp/standard-library/unordered-map) |
 | Java | [`java.util.Map`](https://docs.oracle.com/javase/10/docs/api/java/util/Map.html). Use [`java.util.HashMap`](https://docs.oracle.com/javase/10/docs/api/java/util/HashMap.html) or [`java.util.TreeMap`](https://docs.oracle.com/javase/10/docs/api/java/util/TreeMap.html) (preferred) |
 | Python | [`dict`](https://docs.python.org/3/tutorial/datastructures.html#dictionaries) |
 | JavaScript | [`Object`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) or [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) |


### PR DESCRIPTION
std::map is compare-based, the hash table in the standard library is std::unordered_map
https://en.cppreference.com/w/cpp/container/map
https://en.cppreference.com/w/cpp/container/unordered_map