### PR TITLE
contents(algo): fix typo in math cheat sheet

### DIFF
--- a/contents/algorithms/math.md
+++ b/contents/algorithms/math.md
@@ -47,7 +47,7 @@ When a question involves "whether a number is a multiple of X", the modulo opera
 
 ### Comparing floats
 
-When dealing with floating point numbers, take note of rounding mistakes. Consider using epsilon comparisons instead of equality checks. E.g. `abs(x - y) <= 10e-7` instead of `x == y`.
+When dealing with floating point numbers, take note of rounding mistakes. Consider using epsilon comparisons instead of equality checks. E.g. `abs(x - y) <= 1e-6` instead of `x == y`.
 
 ### Fast operators
 

--- a/contents/algorithms/math.md
+++ b/contents/algorithms/math.md
@@ -47,7 +47,7 @@ When a question involves "whether a number is a multiple of X", the modulo opera
 
 ### Comparing floats
 
-When dealing with floating point numbers, take note of rounding mistakes. Consider using epsilon comparisons instead of equality checks. E.g. `abs(x - y) <= 10e7` instead of `x == y`.
+When dealing with floating point numbers, take note of rounding mistakes. Consider using epsilon comparisons instead of equality checks. E.g. `abs(x - y) <= 10e-7` instead of `x == y`.
 
 ### Fast operators
 


### PR DESCRIPTION
Found a typo in the math cheat sheet for using epsilon comparisons for floats. I believe this should be 10e-7 rather than 10e7, as we would be interested in precision after the decimal.

Please let me know if I am wrong as I am not very familiar with this. 😄