### PR TITLE
[resumes][feat] Add API to submit & query for resume reviews

### DIFF
--- a/apps/portal/prisma/schema.prisma
+++ b/apps/portal/prisma/schema.prisma
@@ -146,8 +146,6 @@ model ResumesCommentVote {
     updatedAt DateTime       @updatedAt
     user      User           @relation(fields: [userId], references: [id], onDelete: Cascade)
     comment   ResumesComment @relation(fields: [commentId], references: [id], onDelete: Cascade)
-
-    @@unique([commentId, userId])
 }
 
 // Start of Offers project models.

--- a/apps/portal/prisma/schema.prisma
+++ b/apps/portal/prisma/schema.prisma
@@ -146,6 +146,8 @@ model ResumesCommentVote {
     updatedAt DateTime       @updatedAt
     user      User           @relation(fields: [userId], references: [id], onDelete: Cascade)
     comment   ResumesComment @relation(fields: [commentId], references: [id], onDelete: Cascade)
+
+    @@unique([commentId, userId])
 }
 
 // Start of Offers project models.

--- a/apps/portal/src/components/resumes/comments/CommentsForm.tsx
+++ b/apps/portal/src/components/resumes/comments/CommentsForm.tsx
@@ -41,6 +41,7 @@ export default function CommentsForm({
   });
   const reviewCreateMutation = trpc.useMutation('resumes.reviews.user.create');
 
+  // TODO: Give a feedback to the user if the action succeeds/fails
   const onSubmit: SubmitHandler<IFormInput> = async (data) => {
     await reviewCreateMutation.mutate({
       resumeId,

--- a/apps/portal/src/components/resumes/comments/CommentsForm.tsx
+++ b/apps/portal/src/components/resumes/comments/CommentsForm.tsx
@@ -65,8 +65,11 @@ export default function CommentsForm({
   };
 
   return (
-    <>
+    <div className="h-[calc(100vh-13rem)] overflow-y-scroll">
       <h2 className="text-xl font-semibold text-gray-800">Add your review</h2>
+      <p className="text-gray-800">
+        Please fill in at least one section to submit your review
+      </p>
 
       <form
         className="w-full space-y-8 divide-y divide-gray-200"
@@ -155,6 +158,6 @@ export default function CommentsForm({
         }}>
         <div>Note that your review will not be saved!</div>
       </Dialog>
-    </>
+    </div>
   );
 }

--- a/apps/portal/src/components/resumes/comments/CommentsForm.tsx
+++ b/apps/portal/src/components/resumes/comments/CommentsForm.tsx
@@ -3,7 +3,10 @@ import type { SubmitHandler } from 'react-hook-form';
 import { useForm } from 'react-hook-form';
 import { Button, Dialog, TextInput } from '@tih/ui';
 
+import { trpc } from '~/utils/trpc';
+
 type CommentsFormProps = Readonly<{
+  resumeId: string;
   setShowCommentsForm: (show: boolean) => void;
 }>;
 
@@ -17,7 +20,9 @@ type IFormInput = {
 
 type InputKeys = keyof IFormInput;
 
+// TODO: Retrieve resumeId and remove default
 export default function CommentsForm({
+  resumeId = '',
   setShowCommentsForm,
 }: CommentsFormProps) {
   const [showDialog, setShowDialog] = useState(false);
@@ -35,10 +40,16 @@ export default function CommentsForm({
       skills: '',
     },
   });
+  const reviewCreateMutation = trpc.useMutation('resumes.reviews.user.create');
 
-  // TODO: Implement mutation to database
-  const onSubmit: SubmitHandler<IFormInput> = (data) => {
-    alert(JSON.stringify(data));
+  const onSubmit: SubmitHandler<IFormInput> = async (data) => {
+    await reviewCreateMutation.mutate({
+      resumeId,
+      ...data,
+    });
+
+    // Redirect back to comments section
+    setShowCommentsForm(false);
   };
 
   const onCancel = () => {

--- a/apps/portal/src/components/resumes/comments/CommentsForm.tsx
+++ b/apps/portal/src/components/resumes/comments/CommentsForm.tsx
@@ -20,9 +20,8 @@ type IFormInput = {
 
 type InputKeys = keyof IFormInput;
 
-// TODO: Retrieve resumeId and remove default
 export default function CommentsForm({
-  resumeId = '',
+  resumeId,
   setShowCommentsForm,
 }: CommentsFormProps) {
   const [showDialog, setShowDialog] = useState(false);

--- a/apps/portal/src/components/resumes/comments/CommentsList.tsx
+++ b/apps/portal/src/components/resumes/comments/CommentsList.tsx
@@ -16,11 +16,10 @@ export default function CommentsList({
 }: CommentsListProps) {
   const [tab, setTab] = useState(COMMENTS_SECTIONS[0].value);
 
-  // TODO: Render comments
   const commentsQuery = trpc.useQuery(['resumes.reviews.list', { resumeId }]);
 
   /* eslint-disable no-console */
-  console.log(commentsQuery);
+  console.log(commentsQuery.data);
   /* eslint-enable no-console */
 
   return (

--- a/apps/portal/src/components/resumes/comments/CommentsList.tsx
+++ b/apps/portal/src/components/resumes/comments/CommentsList.tsx
@@ -1,16 +1,27 @@
 import { useState } from 'react';
 import { Button, Tabs } from '@tih/ui';
 
+import { trpc } from '~/utils/trpc';
+
 import { COMMENTS_SECTIONS } from './constants';
 
 type CommentsListProps = Readonly<{
+  resumeId: string;
   setShowCommentsForm: (show: boolean) => void;
 }>;
 
 export default function CommentsList({
+  resumeId,
   setShowCommentsForm,
 }: CommentsListProps) {
   const [tab, setTab] = useState(COMMENTS_SECTIONS[0].value);
+
+  // TODO: Render comments
+  const commentsQuery = trpc.useQuery(['resumes.reviews.list', { resumeId }]);
+
+  /* eslint-disable no-console */
+  console.log(commentsQuery);
+  /* eslint-enable no-console */
 
   return (
     <>

--- a/apps/portal/src/components/resumes/comments/CommentsList.tsx
+++ b/apps/portal/src/components/resumes/comments/CommentsList.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
-import { Button, Tabs } from '@tih/ui';
+import { Tabs } from '@tih/ui';
 
 import { trpc } from '~/utils/trpc';
 
+import CommentsListButton from './CommentsListButton';
 import { COMMENTS_SECTIONS } from './constants';
 
 type CommentsListProps = Readonly<{
@@ -23,13 +24,8 @@ export default function CommentsList({
   /* eslint-enable no-console */
 
   return (
-    <>
-      <Button
-        display="block"
-        label="Add your review"
-        variant="tertiary"
-        onClick={() => setShowCommentsForm(true)}
-      />
+    <div className="space-y-3">
+      <CommentsListButton setShowCommentsForm={setShowCommentsForm} />
       <Tabs
         label="comments"
         tabs={COMMENTS_SECTIONS}
@@ -37,6 +33,6 @@ export default function CommentsList({
         onChange={(value) => setTab(value)}
       />
       {/* TODO: Add comments lists */}
-    </>
+    </div>
   );
 }

--- a/apps/portal/src/components/resumes/comments/CommentsListButton.tsx
+++ b/apps/portal/src/components/resumes/comments/CommentsListButton.tsx
@@ -1,0 +1,48 @@
+import { signIn, useSession } from 'next-auth/react';
+import { Button } from '@tih/ui';
+
+type CommentsListButtonProps = {
+  setShowCommentsForm: (show: boolean) => void;
+};
+
+export default function CommentsListButton({
+  setShowCommentsForm,
+}: CommentsListButtonProps) {
+  const { data: session, status } = useSession();
+  const isSessionLoading = status === 'loading';
+
+  // Don't render anything
+  if (isSessionLoading) {
+    return null;
+  }
+
+  // Not signed in
+  if (session == null) {
+    return (
+      <div className="flex justify-center">
+        <p>
+          <a
+            className="text-primary-800 hover:text-primary-500"
+            href="/api/auth/signin"
+            onClick={(event) => {
+              event.preventDefault();
+              signIn();
+            }}>
+            Sign in
+          </a>{' '}
+          to join discussion
+        </p>
+      </div>
+    );
+  }
+
+  // Signed in. Return Add review button
+  return (
+    <Button
+      display="block"
+      label="Add your review"
+      variant="tertiary"
+      onClick={() => setShowCommentsForm(true)}
+    />
+  );
+}

--- a/apps/portal/src/components/resumes/comments/CommentsSection.tsx
+++ b/apps/portal/src/components/resumes/comments/CommentsSection.tsx
@@ -3,12 +3,25 @@ import { useState } from 'react';
 import CommentsForm from './CommentsForm';
 import CommentsList from './CommentsList';
 
-export default function CommentsSection() {
+type ICommentsSectionProps = {
+  resumeId: string;
+};
+
+// TODO: Retrieve resumeId for CommentsSection
+export default function CommentsSection({
+  resumeId = '',
+}: ICommentsSectionProps) {
   const [showCommentsForm, setShowCommentsForm] = useState(false);
 
   return showCommentsForm ? (
-    <CommentsForm setShowCommentsForm={setShowCommentsForm} />
+    <CommentsForm
+      resumeId={resumeId}
+      setShowCommentsForm={setShowCommentsForm}
+    />
   ) : (
-    <CommentsList setShowCommentsForm={setShowCommentsForm} />
+    <CommentsList
+      resumeId={resumeId}
+      setShowCommentsForm={setShowCommentsForm}
+    />
   );
 }

--- a/apps/portal/src/components/resumes/comments/constants.ts
+++ b/apps/portal/src/components/resumes/comments/constants.ts
@@ -1,23 +1,24 @@
-// TODO: Move to a general enums/constants file? For resumes
+import { ResumesSection } from '@prisma/client';
+
 export const COMMENTS_SECTIONS = [
   {
     label: 'General',
-    value: 'general',
+    value: ResumesSection.GENERAL,
   },
   {
     label: 'Education',
-    value: 'education',
+    value: ResumesSection.EDUCATION,
   },
   {
     label: 'Experience',
-    value: 'experience',
+    value: ResumesSection.EXPERIENCE,
   },
   {
     label: 'Projects',
-    value: 'projects',
+    value: ResumesSection.PROJECTS,
   },
   {
     label: 'Skills',
-    value: 'skills',
+    value: ResumesSection.SKILLS,
   },
 ];

--- a/apps/portal/src/pages/resumes/review.tsx
+++ b/apps/portal/src/pages/resumes/review.tsx
@@ -73,7 +73,7 @@ export default function ResumeReviewPage() {
           <ResumePdf />
         </div>
         <div className="mx-8 w-1/2">
-          <CommentsSection />
+          <CommentsSection resumeId="" />
         </div>
       </div>
     </main>

--- a/apps/portal/src/server/router/index.ts
+++ b/apps/portal/src/server/router/index.ts
@@ -3,6 +3,7 @@ import superjson from 'superjson';
 import { createRouter } from './context';
 import { protectedExampleRouter } from './protected-example-router';
 import { resumesResumeUserRouter } from './resumes-resume-user-router';
+import { resumeReviewsRouter } from './resumes-reviews-router';
 import { resumesReviewsUserRouter } from './resumes-reviews-user-router';
 import { todosRouter } from './todos';
 import { todosUserRouter } from './todos-user-router';
@@ -16,6 +17,7 @@ export const appRouter = createRouter()
   .merge('todos.', todosRouter)
   .merge('todos.user.', todosUserRouter)
   .merge('resumes.resume.user.', resumesResumeUserRouter)
+  .merge('resumes.reviews.', resumeReviewsRouter)
   .merge('resumes.reviews.user.', resumesReviewsUserRouter);
 
 // Export type definition of API

--- a/apps/portal/src/server/router/index.ts
+++ b/apps/portal/src/server/router/index.ts
@@ -3,6 +3,7 @@ import superjson from 'superjson';
 import { createRouter } from './context';
 import { protectedExampleRouter } from './protected-example-router';
 import { resumesResumeUserRouter } from './resumes-resume-user-router';
+import { resumesReviewsUserRouter } from './resumes-reviews-user-router';
 import { todosRouter } from './todos';
 import { todosUserRouter } from './todos-user-router';
 
@@ -14,7 +15,8 @@ export const appRouter = createRouter()
   .merge('auth.', protectedExampleRouter)
   .merge('todos.', todosRouter)
   .merge('todos.user.', todosUserRouter)
-  .merge('resumes.resume.user.', resumesResumeUserRouter);
+  .merge('resumes.resume.user.', resumesResumeUserRouter)
+  .merge('resumes.reviews.user.', resumesReviewsUserRouter);
 
 // Export type definition of API
 export type AppRouter = typeof appRouter;

--- a/apps/portal/src/server/router/resumes-reviews-router.ts
+++ b/apps/portal/src/server/router/resumes-reviews-router.ts
@@ -2,7 +2,6 @@ import { z } from 'zod';
 
 import { createRouter } from './context';
 
-// TODO: Test this -> Not sure if it works
 export const resumeReviewsRouter = createRouter().query('list', {
   input: z.object({
     resumeId: z.string(),

--- a/apps/portal/src/server/router/resumes-reviews-router.ts
+++ b/apps/portal/src/server/router/resumes-reviews-router.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+
+import { createRouter } from './context';
+
+// TODO: Test this -> Not sure if it works
+export const resumeReviewsRouter = createRouter().query('list', {
+  input: z.object({
+    resumeId: z.string(),
+  }),
+  async resolve({ ctx, input }) {
+    const userId = ctx.session?.user?.id;
+    const { resumeId } = input;
+
+    // For this resume, we retrieve every comment's information, along with:
+    // The user's name and image to render
+    // Number of votes, and whether the user (if-any) has voted
+    return await ctx.prisma.resumesComment.findMany({
+      include: {
+        _count: {
+          select: {
+            votes: true,
+          },
+        },
+        user: {
+          select: {
+            image: true,
+            name: true,
+          },
+        },
+        votes: {
+          where: {
+            userId,
+          },
+        },
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+      where: {
+        resumeId,
+      },
+    });
+  },
+});

--- a/apps/portal/src/server/router/resumes-reviews-router.ts
+++ b/apps/portal/src/server/router/resumes-reviews-router.ts
@@ -28,6 +28,7 @@ export const resumeReviewsRouter = createRouter().query('list', {
           },
         },
         votes: {
+          take: 1,
           where: {
             userId,
           },

--- a/apps/portal/src/server/router/resumes-reviews-user-router.ts
+++ b/apps/portal/src/server/router/resumes-reviews-user-router.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+import { ResumesSection } from '@prisma/client';
+
+import { createProtectedRouter } from './context';
+
+type IResumeCommentInput = Readonly<{
+  description: string;
+  resumeId: string;
+  section: ResumesSection;
+  userId: string;
+}>;
+
+export const resumesReviewsUserRouter = createProtectedRouter().mutation(
+  'create',
+  {
+    input: z.object({
+      education: z.string(),
+      experience: z.string(),
+      general: z.string(),
+      projects: z.string(),
+      resumeId: z.string(),
+      skills: z.string(),
+    }),
+    async resolve({ ctx, input }) {
+      const userId = ctx.session?.user.id;
+      const { resumeId, education, experience, general, projects, skills } =
+        input;
+
+      // For each section, convert them into ResumesComment model if provided
+      const comments: Array<IResumeCommentInput> = [
+        { description: education, section: ResumesSection.EDUCATION },
+        { description: experience, section: ResumesSection.EXPERIENCE },
+        { description: general, section: ResumesSection.GENERAL },
+        { description: projects, section: ResumesSection.PROJECTS },
+        { description: skills, section: ResumesSection.SKILLS },
+      ]
+        .filter(({ description }) => {
+          return description.trim().length > 0;
+        })
+        .map(({ description, section }) => {
+          return {
+            description,
+            resumeId,
+            section,
+            userId,
+          };
+        });
+
+      return await ctx.prisma.resumesComment.createMany({
+        data: comments,
+      });
+    },
+  },
+);


### PR DESCRIPTION
What's new:
- Set up the backend route to create resume reviews.
- Set up route to query for reviews of a given `resumeId`

How to test:
- Currently incomplete as `review.tsx` does not contain `resumeId` required for mutation and query. Need to pass `resumeId` from `Browse` > `Review` > `CommentSection` component for this to work properly
- For local testing: Add a dummy resume with the `Submit` form and hard-code `resumeId` in `CommentSection`

Fields queried for comment:
- Comment information
- User name, image
- Number of votes 
- Whether the user (if-any) has voted this comment
