### PR TITLE
[questions][fix] tweak question filters

### DIFF
--- a/apps/portal/src/components/questions/filter/FilterSection.tsx
+++ b/apps/portal/src/components/questions/filter/FilterSection.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import type { UseFormRegisterReturn } from 'react-hook-form';
 import { useForm } from 'react-hook-form';
-import { CheckboxInput, Collapsible, RadioList } from '@tih/ui';
+import { CheckboxInput, CheckboxList, Collapsible, RadioList } from '@tih/ui';
 
 export type FilterChoice<V extends string = string> = {
   id: string;
@@ -96,7 +96,7 @@ export default function FilterSection<V extends string>({
       <Collapsible defaultOpen={true} label={collapsibleLabel}>
         <div className="-mx-2 flex flex-col items-stretch gap-2">
           {!showAll && (
-            <div className="z-10">
+            <div>
               {renderInput({
                 field,
                 onOptionChange: async (option: FilterOption<V>) => {
@@ -110,8 +110,8 @@ export default function FilterSection<V extends string>({
               })}
             </div>
           )}
-          {isSingleSelect ? (
-            <div className="px-1.5">
+          <div className="px-1.5">
+            {isSingleSelect ? (
               <RadioList
                 isLabelHidden={true}
                 label={label}
@@ -133,26 +133,26 @@ export default function FilterSection<V extends string>({
                   />
                 ))}
               </RadioList>
-            </div>
-          ) : (
-            <div className="px-1.5">
-              {options
-                .filter((option) => showAll || option.checked)
-                .map((option) => (
-                  <CheckboxInput
-                    key={option.value}
-                    label={option.label}
-                    value={option.checked}
-                    onChange={(checked) => {
-                      onOptionChange({
-                        ...option,
-                        checked,
-                      });
-                    }}
-                  />
-                ))}
-            </div>
-          )}
+            ) : (
+              <CheckboxList isLabelHidden={true} label={label}>
+                {options
+                  .filter((option) => showAll || option.checked)
+                  .map((option) => (
+                    <CheckboxInput
+                      key={option.value}
+                      label={option.label}
+                      value={option.checked}
+                      onChange={(checked) => {
+                        onOptionChange({
+                          ...option,
+                          checked,
+                        });
+                      }}
+                    />
+                  ))}
+              </CheckboxList>
+            )}
+          </div>
         </div>
       </Collapsible>
     </div>

--- a/apps/storybook/stories/checkbox-list.stories.tsx
+++ b/apps/storybook/stories/checkbox-list.stories.tsx
@@ -14,6 +14,9 @@ export default {
     description: {
       control: 'text',
     },
+    isLabelHidden: {
+      control: 'boolean',
+    },
     label: {
       control: 'text',
     },


### PR DESCRIPTION
- Radio spacing too large: This spacing is actually fine, the checkboxes weren't using the `CheckboxList` component, which would use the same amount of spacing as the `RadioList`.
- Typeahead overlapping issue: There was a `z-10` added to a `<div>` wrapping the typeahead. I think because I fixed the issue within the `Typeahead` component, there's no longer a need for that z-index. Lemme know if I'm missing something here.

cc @jeffsieu 