### PR TITLE
Update README.md for Meta renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Besides the usual algorithm questions, other **awesome** stuff includes:
 - [How to prepare](https://www.techinterviewhandbook.org/coding-interview-prep/) for coding interviews
 - [Coding interview best practices](https://www.techinterviewhandbook.org/coding-interview-cheatsheet/) - Straight-to-the-point Do's and Don'ts
 - [Algorithm cheatsheets and tips](https://www.techinterviewhandbook.org/algorithms/study-cheatsheet/) categorized by topic
-- [Step-by-step Software Engineer resume guide](https://www.techinterviewhandbook.org/resume/) to prepare a FAANG-ready resume
+- [Step-by-step Software Engineer resume guide](https://www.techinterviewhandbook.org/resume/) to prepare a MAANG-ready resume
 - [Behavioral questions](https://www.techinterviewhandbook.org/behavioral-interview-questions/) asked by the top tech companies
 - [Front end interview preparation](https://www.frontendinterviewhandbook.com)
 


### PR DESCRIPTION
`FAANG` is now `MAANG` by the renaming from Facebook to Meta.