### PR TITLE
contents(algo): remove java.util.TreeMap from Hashtable implementations

### DIFF
--- a/apps/website/contents/algorithms/hash-table.md
+++ b/apps/website/contents/algorithms/hash-table.md
@@ -44,7 +44,7 @@ In the case of hash collisions, there are a number of collision resolution techn
 | Language | API |
 | --- | --- |
 | C++ | [`std::unordered_map`](https://docs.microsoft.com/en-us/cpp/standard-library/unordered-map) |
-| Java | [`java.util.Map`](https://docs.oracle.com/javase/10/docs/api/java/util/Map.html). Use [`java.util.HashMap`](https://docs.oracle.com/javase/10/docs/api/java/util/HashMap.html) or [`java.util.TreeMap`](https://docs.oracle.com/javase/10/docs/api/java/util/TreeMap.html) (preferred) |
+| Java | [`java.util.Map`](https://docs.oracle.com/javase/10/docs/api/java/util/Map.html). Use [`java.util.HashMap`](https://docs.oracle.com/javase/10/docs/api/java/util/HashMap.html) |
 | Python | [`dict`](https://docs.python.org/3/tutorial/datastructures.html#dictionaries) |
 | JavaScript | [`Object`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) or [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) |
 


### PR DESCRIPTION
java.util.TreeMap is actually an implementation of the Red-Black tree, rather than a hashtable. This is a minor change to remove that from the list of implementations for hastable in Java.

