### PR TITLE
contents: style of Palantir questions is aligned with style of other questions

### DIFF
--- a/apps/website/contents/behavioral-interview-questions.md
+++ b/apps/website/contents/behavioral-interview-questions.md
@@ -147,8 +147,8 @@ Source: [Glassdoor](https://www.glassdoor.com/Interview/Lyft-Interview-Questions
 
 ## Palantir Software Engineer behavioral interview questions
 
-- **What is something 90% of people disagree with you about?**
-- **What is broken around you?**
+- What is something 90% of people disagree with you about?
+- What is broken around you?
 - How do you deal with difficult coworkers? Think about specific instances where you resolved conflicts.
 - How did you win over the difficult employees?
 - Tell me about an analytical problem that you have worked on in the past.


### PR DESCRIPTION
Two first behavioural questions for Palantir were styled as **bold**.  After the change they have the same styling as any other behavioural questions in this document.