### PR TITLE
contents(queue): fix typo in queue content

### DIFF
--- a/apps/website/contents/algorithms/queue.md
+++ b/apps/website/contents/algorithms/queue.md
@@ -55,7 +55,7 @@ Breadth-first search is commonly implemented using queues.
 
 ## Things to look out for during interviews
 
-Most languages don't have a built-in Queue class which can be used, and candidates often use arrays (JavaScript) or lists (Python) as a queue. However, note that the dequeue operation in such a scenario will be O(n) because it requires shifting of all other elements by one. In such cases, you can flag this to the interviewer and say that you assume that there's a queue data structure to use which has an efficient dequeue operation.
+Most languages don't have a built-in Queue class which can be used, and candidates often use arrays (JavaScript) or lists (Python) as a queue. However, note that the dequeue operation (assuming the front of the queue is on the left) in such a scenario will be O(n) because it requires shifting of all other elements left by one. In such cases, you can flag this to the interviewer and say that you assume that there's a queue data structure to use which has an efficient dequeue operation.
 
 ## Corner cases
 

--- a/apps/website/contents/algorithms/queue.md
+++ b/apps/website/contents/algorithms/queue.md
@@ -55,7 +55,7 @@ Breadth-first search is commonly implemented using queues.
 
 ## Things to look out for during interviews
 
-Most languages don't have a built-in Queue class which can be used, and candidates often use arrays (JavaScript) or lists (Python) as a queue. However, note that the enqueue operation in such a scenario will be O(n) because it requires shifting of all other elements by one. In such cases, you can flag this to the interviewer and say that you assume that there's a queue data structure to use which has an efficient enqueue operation.
+Most languages don't have a built-in Queue class which can be used, and candidates often use arrays (JavaScript) or lists (Python) as a queue. However, note that the dequeue operation in such a scenario will be O(n) because it requires shifting of all other elements by one. In such cases, you can flag this to the interviewer and say that you assume that there's a queue data structure to use which has an efficient dequeue operation.
 
 ## Corner cases
 


### PR DESCRIPTION
Fixed a typo in the "Things to look out for during interviews" section. It previously stated that enqueue had a time complexity issue in languages without built-in Queue classes using arrays. It's actually the dequeue operation that's O(n) due to front removal and shifting of elements. Fixing this small typo for clarity.