### PR TITLE
[Content] Add Hello Interview to mock interviews

### DIFF
--- a/apps/website/contents/mock-interviews.md
+++ b/apps/website/contents/mock-interviews.md
@@ -46,3 +46,11 @@ What makes Meetapro stand out?
 - Expert interviewers: Veterans from FAANG and top-tier companies bring years of experience, offering priceless feedback that truly makes a difference.
 - Direct communication: Job seekers can directly message interviewers to address any questions or concerns, such as experience sharing or rescheduling, ensuring better preparation for both parties.
 - All-in-one tools: Meetapro equips you with the essential tools for an effective interview session, including recording options for post-session review.
+
+## [Hello Interview](https://www.hellointerview.com/?utm_source=techinterviewhandbook)
+
+**Disclaimer: This section was added by the Hello Interview team**
+
+Hello Interview uses a combination of AI and expert FAANG staff engineers and managers to help you prepare for your interview. Practice with AI at your own pace on system design, behavioral, or coding interviews. Schedule mock interviews with a human for detailed, 360 degree feedback on all aspects of your interview from domain knowledge and techniques to presentation skills and communication.
+
+Hello Interview offers included services from resume reviews to salary negotiation and offer decision support ensuring you're able to enter your minimize the time spent preparing and maximize the result of your interview journey.

--- a/apps/website/contents/mock-interviews.md
+++ b/apps/website/contents/mock-interviews.md
@@ -34,6 +34,14 @@ Another platform that allows you to practice coding interviews is [Pramp](https:
 
 Personally, I am not that fond of Pramp's approach because if I were to interview someone, I would rather choose a question I am familiar with. Also, many users of the platform do not have the experience of being interviewers and that can result in a horrible interview experience. There was once where my matched peer, as the interviewer, did not have the right understanding of the question and attempted to lead me down the wrong path of solving the question. However, this is more of a problem of the candidate than the platform though.
 
+## [Hello Interview](https://www.hellointerview.com/?utm_source=techinterviewhandbook)
+
+**Disclaimer: This section was added by the Hello Interview team**
+
+Hello Interview uses a combination of AI and expert FAANG staff engineers and managers to help you prepare for your interview. Practice with AI at your own pace on system design, behavioral, or coding interviews. Schedule mock interviews with a human for detailed, 360 degree feedback on all aspects of your interview from domain knowledge and techniques to presentation skills and communication.
+
+Hello Interview offers included services from resume reviews to salary negotiation and offer decision support ensuring you're able to minimize the time spent preparing and maximize the result of your interview journey.
+
 ## [Meetapro](https://meetapro.com/?utm_source=techinterviewhandbook)
 
 **Disclaimer: This section was added by the Meetapro team**
@@ -47,10 +55,3 @@ What makes Meetapro stand out?
 - Direct communication: Job seekers can directly message interviewers to address any questions or concerns, such as experience sharing or rescheduling, ensuring better preparation for both parties.
 - All-in-one tools: Meetapro equips you with the essential tools for an effective interview session, including recording options for post-session review.
 
-## [Hello Interview](https://www.hellointerview.com/?utm_source=techinterviewhandbook)
-
-**Disclaimer: This section was added by the Hello Interview team**
-
-Hello Interview uses a combination of AI and expert FAANG staff engineers and managers to help you prepare for your interview. Practice with AI at your own pace on system design, behavioral, or coding interviews. Schedule mock interviews with a human for detailed, 360 degree feedback on all aspects of your interview from domain knowledge and techniques to presentation skills and communication.
-
-Hello Interview offers included services from resume reviews to salary negotiation and offer decision support ensuring you're able to minimize the time spent preparing and maximize the result of your interview journey.

--- a/apps/website/contents/mock-interviews.md
+++ b/apps/website/contents/mock-interviews.md
@@ -53,4 +53,4 @@ What makes Meetapro stand out?
 
 Hello Interview uses a combination of AI and expert FAANG staff engineers and managers to help you prepare for your interview. Practice with AI at your own pace on system design, behavioral, or coding interviews. Schedule mock interviews with a human for detailed, 360 degree feedback on all aspects of your interview from domain knowledge and techniques to presentation skills and communication.
 
-Hello Interview offers included services from resume reviews to salary negotiation and offer decision support ensuring you're able to enter your minimize the time spent preparing and maximize the result of your interview journey.
+Hello Interview offers included services from resume reviews to salary negotiation and offer decision support ensuring you're able to minimize the time spent preparing and maximize the result of your interview journey.


### PR DESCRIPTION
Adding https://www.hellointerview.com to mock interviews. Added similar disclaimer to meetapro (though I'd love to hear any  take you might have!)

Thanks so much for building TIH, what an invaluable resource for the SWE community.

Oblig. testing image:
![image](https://github.com/yangshun/tech-interview-handbook/assets/93804/78f98fa1-2187-44b9-8dda-34f6a60c3178)
