### PR TITLE
contents: Add Misc > Career Growth Page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .DS_Store
 node_modules
 .turbo

--- a/apps/website/contents/career-growth.md
+++ b/apps/website/contents/career-growth.md
@@ -1,0 +1,47 @@
+---
+id: career-growth
+title: Career growth
+---
+
+After being hired, it's crucial to focus on your career growth so you don't stagnate.
+
+This gives you the resources to get promoted and improve your skill set as an engineer.
+
+## Newsletters
+- [High Growth Engineer](https://careercutler.substack.com/)
+- [The Developing Dev](https://www.developing.dev/)
+- [Level up software engineering](https://levelupsoftwareengineering.substack.com/)
+- [Engineer’s Codex](https://engineercodex.substack.com/)
+- [Techlead Mentor](https://open.substack.com/pub/ravirajachar)
+- [Data Engineering Newsletter](https://blog.dataengineer.io/)
+- [The Caring Techie](https://www.thecaringtechie.com/)
+- [Refactoring](https://refactoring.fm/)
+- [Strategize Your Career](https://strategizeyourcareer.substack.com/)
+- [Saiyan Growth Letter](https://www.saiyangrowthletter.com/)
+
+## Software Engineer Career Growth Books
+- [Software Engineer's Guidebook](https://www.amazon.com/Software-Engineers-Guidebook-Navigating-positions/dp/908338182X)
+- [Engineers Survival Guide](https://www.amazon.com/Engineers-Survival-Guide-Facebook-Microsoft/dp/B09MBZBGFK)
+- [The Coding Career Handbook](https://learninpublic.org/)
+- [The Complete Software Developer's Career Guide](https://www.amazon.com/Complete-Software-Developers-Career-Guide-ebook/dp/B073X6GNJ1)
+- [Omar Halabieh 90-day career blueprint](https://www.omarhalabieh.com/90-day-career-blueprint/)
+- [Get Promoted](https://www.amazon.com/Get-Promoted-Really-Missing-Holding-ebook/dp/B09WGJVR4Z)
+- [StaffEng.com – Stories of reaching Staff-plus engineering roles](https://staffeng.com/)
+
+## YouTube Channels
+- [Theo - t3.gg](https://www.youtube.com/@t3dotgg)
+- [Fireship](https://www.youtube.com/@Fireship)
+- [ThePrimeTime / Primeagen](https://www.youtube.com/@ThePrimeTimeagen)
+- [LeadDev](https://www.youtube.com/@LeadDev/videos)
+
+## Communities
+- [Taro](https://www.jointaro.com/)
+- [Kent C. Dodds Discord Community](https://kentcdodds.com/discord)
+- [Theo - T3](https://discord.com/invite/xHdCpcPHRE)
+- [Frontend Mentor](https://www.frontendmentor.io/)
+
+## References
+- [Path to Senior Engineer Handbook](https://github.com/jordan-cutler/path-to-senior-engineer-handbook)
+
+
+

--- a/apps/website/contents/career-growth.md
+++ b/apps/website/contents/career-growth.md
@@ -42,6 +42,3 @@ This gives you the resources to get promoted and improve your skill set as an en
 
 ## References
 - [Path to Senior Engineer Handbook](https://github.com/jordan-cutler/path-to-senior-engineer-handbook)
-
-
-

--- a/apps/website/sidebars.js
+++ b/apps/website/sidebars.js
@@ -104,7 +104,7 @@ module.exports = {
       ],
     },
     {
-      Misc: [
+      'Beyond the interview': [
         'interview-formats-top-companies',
         'interviewer-cheatsheet',
         'landscape',

--- a/apps/website/sidebars.js
+++ b/apps/website/sidebars.js
@@ -109,6 +109,7 @@ module.exports = {
         'interviewer-cheatsheet',
         'landscape',
         'engineering-levels',
+        'career-growth',
         'best-coding-interview-courses',
         'best-practice-questions',
       ],


### PR DESCRIPTION
Spoke with @yangshun: We can add a "Career Growth" page under Misc which points to some of the top resources for engineers to grow in their careers.

I curated the resources that will be most relevant and I can personally attest to from the [Path to Senior Engineer Handbook](https://github.com/jordan-cutler/path-to-senior-engineer-handbook)

![CleanShot 2023-11-26 at 10 43 25@2x](https://github.com/yangshun/tech-interview-handbook/assets/13022754/30060418-ef89-4c6f-88fb-24bf7409d823)
