### PR TITLE
contents(beyond): add 16x Engineer

### DIFF
--- a/apps/website/contents/career-growth.md
+++ b/apps/website/contents/career-growth.md
@@ -21,6 +21,7 @@ After being hired, it's crucial to focus on your career growth so you don't stag
 - [Strategize Your Career](https://strategizeyourcareer.substack.com/)
 - [Saiyan Growth Letter](https://www.saiyangrowthletter.com/)
 - [Data Engineering Newsletter](https://blog.dataengineer.io/)
+- [16x Engineer](https://16x.engineer/)
 
 ## Books
 


### PR DESCRIPTION
Add 16x Engineer created by myself: https://16x.engineer/

It is a website dedicated to resources on Software Engineer Career and Personal Growth, with a focus on Asia and Singapore tech industry.

Since there is no dedicated website category, I have parked in under newsletter (the website does have its own newsletter).