### PR TITLE
[content] fix typo on Self Introduction page

### DIFF
--- a/apps/website/contents/self-introduction.md
+++ b/apps/website/contents/self-introduction.md
@@ -84,7 +84,7 @@ Having an elevator pitch on hand is a great way to create a network and chance u
 
 Qualities that a Front End engineer should possess.
 
-> "It receives over a million pageviews a month and is used by over 30,000 NUS undergraduates and even some professors."
+> "It receives over a million pageviews a month and is used by over 40,000 NUS undergraduates and even some professors."
 
 Mention something about the project which stands out.
 
@@ -112,6 +112,6 @@ Same as above, qualities that a Front End engineer should possess.
 
 Lyft was Grab's sister company! In fact they even had a partnership in the past. Most Lyft engineers would have heard of Grab before and mentioning this catches their attention.
 
-> "I built the project with another engineer over the period of 4 months on a React/Redux and Golang stack."
+> "I built the project with another engineer over the period of 3 months on a React/Redux and Golang stack."
 
 Acknowledge that you work with others. Building a non-trivial system with just 2 people in 3 months is quite good for a non-trivial system. Lyft also uses Golang for their high performance systems.


### PR DESCRIPTION
Updated text on self introduction page to match references to it further down in the breakdown section.

![Screenshot 2024-01-31 at 11 15 44 pm](https://github.com/yangshun/tech-interview-handbook/assets/36926781/d6440876-fb28-4ea4-843e-f7e6835fab88)
