### PR TITLE
Update transposition snippet (python)

### DIFF
--- a/apps/website/contents/algorithms/matrix.md
+++ b/apps/website/contents/algorithms/matrix.md
@@ -59,7 +59,7 @@ Many grid-based games can be modeled as a matrix, such as Tic-Tac-Toe, Sudoku, C
 Transposing a matrix in Python is simply:
 
 ```py
-transposed_matrix = zip(*matrix)
+transposed_matrix = [[matrix[i][j] for i in range(len(matrix))] for j in range(len(matrix[0]))]
 ```
 
 ## Essential questions


### PR DESCRIPTION
`zip`ping the matrix is a nice trick but it doesn't always produce what you need (a matrix) in a time-sensitive interview environment. The output of `zip` is an iterator of tuples which doesn't allow accessing elements by index. Converting the iterator of tuples to matrix takes the same amount of code as transposing the matrix itself

`transposed_matrix[0][0]` will raise an error
`TypeError: 'zip' object is not subscriptable`