### PR TITLE
contents: add linked list implementation in C++

### DIFF
--- a/apps/website/contents/algorithms/linked-list.md
+++ b/apps/website/contents/algorithms/linked-list.md
@@ -62,7 +62,7 @@ Out of the common languages, only Java provides a linked list implementation. Th
 
 | Language | API |
 | --- | --- |
-| C++ | N/A |
+| C++ | [`std::list`](https://en.cppreference.com/w/cpp/container/list) |
 | Java | [`java.util.LinkedList`](https://docs.oracle.com/javase/10/docs/api/java/util/LinkedList.html) |
 | Python | N/A |
 | JavaScript | N/A |


### PR DESCRIPTION
Add `std::list` as the linked list implementation in C++.