### PR TITLE
[fix] update hyperlink for "Open a pull request!" on home page

### DIFF
--- a/apps/website/src/pages/index.js
+++ b/apps/website/src/pages/index.js
@@ -745,7 +745,7 @@ function SuccessStoriesSection() {
         <p className="margin-vert--lg text--center">
           Would you like to contribute a success story?{' '}
           <a
-            href="https://github.com/yangshun/tech-interview-handbook/edit/master/website/src/data/successStories.js"
+            href="https://github.com/yangshun/tech-interview-handbook/edit/main/apps/website/src/data/successStories.js"
             rel="noopener"
             target="_blank">
             Open a Pull Request here


### PR DESCRIPTION
This PR should close #665, I have changed the hyperlink for the text `Open a pull request!` specificially in [this file](https://github.com/yangshun/tech-interview-handbook/blob/main/apps/website/src/pages/index.js) from this [invalid link](https://github.com/yangshun/tech-interview-handbook/edit/master/website/src/data/successStories.js) to the [working link](https://github.com/yangshun/tech-interview-handbook/edit/main/apps/website/src/data/successStories.js). As previously mentioned, it is advised that you edit the issue #255, adding the working link instead.