### PR TITLE
fix: created a margin between buttons

### DIFF
--- a/apps/website/src/pages/index.js
+++ b/apps/website/src/pages/index.js
@@ -801,7 +801,7 @@ function SponsorshipSection() {
             </div>
             <div className="margin-top--lg text--center">
               <a
-                className="button button--primary button--lg margin-right--md"
+                className="button button--primary button--lg margin-right--md margin-bottom--sm"
                 href="mailto:contact@techinterviewhandbook.org"
                 rel="noopener"
                 target="_blank">


### PR DESCRIPTION
I was using the handbook in my phone and noticed a small frontend issue between two buttons, they were overlapping a little.

**BEFORE**

![image](https://github.com/user-attachments/assets/e50d081a-e9f9-4fff-9e66-268287825537)

**AFTER**

![image](https://github.com/user-attachments/assets/6cf64895-e5b7-4120-8899-fbe5a63155c7)

I am opening a pr for this. 