### PR TITLE
Fix Matrix Transpose Logic

### DIFF
--- a/apps/website/contents/algorithms/matrix.md
+++ b/apps/website/contents/algorithms/matrix.md
@@ -59,7 +59,7 @@ Many grid-based games can be modeled as a matrix, such as Tic-Tac-Toe, Sudoku, C
 Transposing a matrix in Python is simply:
 
 ```py
-transposed_matrix = zip(*matrix)
+transposed_matrix = list(zip(*matrix))
 ```
 
 ## Essential questions


### PR DESCRIPTION
This PR adds a simple fix for a logical error. The `zip` function actually returns an object so we need to wrap it with `list()` to return it to it's original _matrix_ form.