### PR TITLE
fix: update the broken hyperlink for "Master the sliding window technique" on arrays

### DIFF
--- a/apps/website/contents/algorithms/array.md
+++ b/apps/website/contents/algorithms/array.md
@@ -82,7 +82,7 @@ Note that because both arrays and strings are sequences (a string is an array of
 
 ### Sliding window
 
-Master the [sliding window technique](https://discuss.leetcode.com/topic/30941/here-is-a-10-line-template-that-can-solve-most-substring-problems) that applies to many subarray/substring problems. In a sliding window, the two pointers usually move in the same direction will never overtake each other. This ensures that each value is only visited at most twice and the time complexity is still O(n). Examples: [Longest Substring Without Repeating Characters](https://leetcode.com/problems/longest-substring-without-repeating-characters/), [Minimum Size Subarray Sum](https://leetcode.com/problems/minimum-size-subarray-sum/), [Minimum Window Substring](https://leetcode.com/problems/minimum-window-substring/)
+Master the [sliding window technique](https://leetcode.com/problems/minimum-window-substring/solutions/26808/here-is-a-10-line-template-that-can-solve-most-substring-problems/) that applies to many subarray/substring problems. In a sliding window, the two pointers usually move in the same direction will never overtake each other. This ensures that each value is only visited at most twice and the time complexity is still O(n). Examples: [Longest Substring Without Repeating Characters](https://leetcode.com/problems/longest-substring-without-repeating-characters/), [Minimum Size Subarray Sum](https://leetcode.com/problems/minimum-size-subarray-sum/), [Minimum Window Substring](https://leetcode.com/problems/minimum-window-substring/)
 
 ### Two pointers
 


### PR DESCRIPTION
In arrays section, there's a leetcode reference for **_Master the sliding window technique_**. Currently, the [existing link](https://discuss.leetcode.com/topic/30941/here-is-a-10-line-template-that-can-solve-most-substring-problems) redirects to https://leetcode.com/discuss/post/topic/30941/ which is broken. This patch updates the link to the originally referred post in Leetcode.

**Before patch:**
<img width="1505" alt="Screenshot 2025-04-27 at 11 29 06 PM" src="https://github.com/user-attachments/assets/7c605f49-9afa-4fb3-b24e-a7746fc10152" />

**After patch:**
<img width="1505" alt="Screenshot 2025-04-27 at 11 37 03 PM" src="https://github.com/user-attachments/assets/54571365-12d5-4ec8-8d79-f480c3872e59" />
