### PR TITLE
seo: fix 3xx redirects issue

### DIFF
--- a/apps/website/blog/2022-07-09-getting-a-tech-job-as-an-undergraduate.md
+++ b/apps/website/blog/2022-07-09-getting-a-tech-job-as-an-undergraduate.md
@@ -51,7 +51,7 @@ I am about to recommend relevant sections to go in sequentially and how to syste
    - Now with virtual interviews, some companies tend to use HackerRank live to conduct whiteboard interviews. Prepare a pen and paper beside you as you work along. Prepare to remote desktop protocol (RDP) into your computer to show step-by-step workings.
    - Do not blurt out the solution straightaway as interviewers can tell that you memorize.
 
-4. Last but not least for algorithms heavy interviews, you might really want to save your time looking at [Grind 75](https://techinterviewhandbook.org/grind75). It's a useful curated source of questions to note how much you can prepare for your interview.
+4. Last but not least for algorithms heavy interviews, you might really want to save your time looking at [Grind 75](https://www.techinterviewhandbook.org/grind75/). It's a useful curated source of questions to note how much you can prepare for your interview.
 
 5. Always be prepared for even system design questions! You will never know what comes your way and this is where your projects come in and how much of good practices you apply in them and what do you learn. The [System Design Primer](https://github.com/donnemartin/system-design-primer) is a good start.
 

--- a/apps/website/contents/best-practice-questions.md
+++ b/apps/website/contents/best-practice-questions.md
@@ -19,7 +19,7 @@ import InDocAd from './\_components/InDocAd';
 
 :::tip
 
-As of April 2022, I've developed a [12-week study plan](./coding-interview-study-plan.md) which includes a curriculum for revision and practice questions. If you want to customize your own practice questions, I've also developed [Grind 75](https://www.techinterviewhandbook.org/grind75) which is a modern version of Blind 75 that you can customize.
+As of April 2022, I've developed a [12-week study plan](./coding-interview-study-plan.md) which includes a curriculum for revision and practice questions. If you want to customize your own practice questions, I've also developed [Grind 75](https://www.techinterviewhandbook.org/grind75/) which is a modern version of Blind 75 that you can customize.
 
 :::
 

--- a/apps/website/contents/coding-interview-prep.md
+++ b/apps/website/contents/coding-interview-prep.md
@@ -81,7 +81,7 @@ How long does it take to prepare for a coding interview? It actually depends on 
 
 To start preparing for your coding interviews, always begin with a plan. Calculate the amount of time you have left to realistically prepare for your interview from now till the day of the coding test, and carefully make a plan of the topics and questions you will cover per day, prioritizing the most important ones first.
 
-But how do you know which are the most important topics and questions to practice based on the time you have left? You may use the free [Grind 75 tool](https://www.techinterviewhandbook.org/grind75) (built by me) which produces coding interview study plans for varying lengths of preparation time. The algorithm behind it includes a ranking of questions by priority and also a balance between breadth and depth of topics covered.
+But how do you know which are the most important topics and questions to practice based on the time you have left? You may use the free [Grind 75 tool](https://www.techinterviewhandbook.org/grind75/) (built by me) which produces coding interview study plans for varying lengths of preparation time. The algorithm behind it includes a ranking of questions by priority and also a balance between breadth and depth of topics covered.
 
 If you have the luxury of time to prepare, it is recommended to spend around 3 months (2-3 hours per day) to prepare more holistically. I came up with a [personal 3-month study plan](./coding-interview-study-plan.md), which takes you from start to finish on which topics and questions to complete.
 

--- a/apps/website/contents/software-engineering-interview-guide.md
+++ b/apps/website/contents/software-engineering-interview-guide.md
@@ -131,7 +131,7 @@ However, LeetCode has thousands of questions and it can be daunting to know wher
 
 The recommended time period to set aside for coding interview preparation is 3 months (11 hours a week i.e. 2-3 hours a day) for a more holistic preparation. I shared my [3 month study plan here](./coding-interview-study-plan.md), which provides a list of coding interview topics with resources and practice questions that you should work through in order of priority every week. I will also be adding content on recommended 1 month and 1 week study plans soon.
 
-If you have less than 3 months to prepare, you can generate your own study plans using the [Grind 75 tool](https://www.techinterviewhandbook.org/grind75) (built by me) which generates recommended study plans for coding interviews based on the time you have left. The algorithm behind it includes a ranking of questions by priority and also a balance between breadth and depth of topics covered.
+If you have less than 3 months to prepare, you can generate your own study plans using the [Grind 75 tool](https://www.techinterviewhandbook.org/grind75/) (built by me) which generates recommended study plans for coding interviews based on the time you have left. The algorithm behind it includes a ranking of questions by priority and also a balance between breadth and depth of topics covered.
 
 ### Resources to use in your practice
 

--- a/apps/website/docusaurus.config.js
+++ b/apps/website/docusaurus.config.js
@@ -42,7 +42,7 @@ module.exports = {
         { label: 'Blog', to: 'blog', position: 'left' },
         {
           label: 'Grind 75',
-          href: 'https://www.techinterviewhandbook.org/grind75',
+          href: 'https://www.techinterviewhandbook.org/grind75/',
           position: 'left',
         },
         {
@@ -147,7 +147,7 @@ module.exports = {
           items: [
             {
               label: 'Grind 75',
-              href: 'https://www.techinterviewhandbook.org/grind75',
+              href: 'https://www.techinterviewhandbook.org/grind75/',
             },
             {
               label: 'Front End Interview Handbook',

--- a/apps/website/src/data/successStories.js
+++ b/apps/website/src/data/successStories.js
@@ -153,7 +153,7 @@ export default [
         <br />
         My favourite part is the{' '}
         <a
-          href="https://www.techinterviewhandbook.org/grind75"
+          href="https://www.techinterviewhandbook.org/grind75/"
           target="_blank"
           rel="noreferrer noopener">
           Grind 75 Tool


### PR DESCRIPTION
Ensure all grind 75 links are `https://www.techinterviewhandbook.org/grind75/` mostly by adding trailing slashes, added www for one link