### PR TITLE
seo: fix HTML lang attribute missing

### DIFF
--- a/apps/portal/src/pages/_document.tsx
+++ b/apps/portal/src/pages/_document.tsx
@@ -2,7 +2,7 @@ import { Head, Html, Main, NextScript } from 'next/document';
 
 export default function Document() {
   return (
-    <Html className="bg-slate-50">
+    <Html lang="en" className="bg-slate-50">
       <Head />
       <body>
         <Main />


### PR DESCRIPTION
app.techinterviewhandbook.org slugs were missing HTML lang attribute