### PR TITLE
contents: add additional behavioral interview content

### DIFF
--- a/apps/website/contents/behavioral-interview-senior-candidates.md
+++ b/apps/website/contents/behavioral-interview-senior-candidates.md
@@ -1,0 +1,111 @@
+---
+id: behavioral-interview-senior-candidates
+title: 'Behavioral interviews for senior candidates'
+description: How to prepare for Software Engineer behavioral interviews as a senior candidate
+keywords:
+  [
+    software engineer behavioral interview prep,
+    software developer behavioral interview prep,
+    behavioral interview software engineer,
+    how to prepare for behavioral interview software engineer,
+    google behavioral interview,
+    facebook behavioral interview,
+    amazon behavioral interview,
+    microsoft behavioral interview,
+    senior behavioral interview,
+    staff engineer behavioral interview,
+    principal engineer behavioral interview,
+  ]
+sidebar_label: Preparing for senior candidates
+---
+
+import InDocAd from './\_components/InDocAd';
+
+_The following page is a collaboration with [Austen McDonald](https://www.linkedin.com/in/austenmc/), former Senior Engineering Manager and Hiring Committee Chair at Meta, and author of [Mastering Behavioral Interviews](http://thebehavioral.tech/)._
+
+As you advance in your engineering career, behavioral interviews become increasingly critical—and challenging. While junior engineers might skate by with weak behavioral performance if their coding is strong, senior roles (Staff+ and above) hinge on these conversations. You're being evaluated for your ability to drive organizational impact, navigate complexity, and lead others.
+
+The stakes are higher too. Senior hiring mistakes cascade across teams, making interviewers naturally more cautious. A Staff Engineer who can't resolve cross-team conflicts or a Principal who struggles with ambiguous technical decisions can derail entire initiatives.
+
+Here are some key ways to approach and improve your behavioral interviews as a senior candidate.
+
+## Common Pitfalls in Senior Behaviorals
+
+While senior candidates face many of the same challenges as other candidates, they encounter unique pitfalls that can undermine their interviews. These stem from both higher expectations and the complexity of leadership work itself.
+
+**Lack of structure leading to incomplete signal coverage:** Unlike junior candidates who might be prodded through their stories by the interviewer, senior candidates are expected to proactively demonstrate their scope. The problem compounds when interviewers interrupt or dive into rabbit holes, as they often do at this level. As a senior candidate, you need to guide the conversation toward the most relevant signal—which means knowing what that signal is in advance. See Story Organization below.
+
+**Neglecting the full spectrum of leadership:** Senior roles require influence across multiple dimensions, but candidates often tell stories from only one perspective. I frequently hear stories focused purely on technical decisions or product outcomes, missing the equally important people leadership; risk, capacity, and change management; strategy work; and stakeholder management aspects. See Choosing Projects below.
+
+**Communicating actions, leaving out frameworks:** Senior candidates should demonstrate systematic thinking, including the decision-making framework that led to those actions. Simply listing individual actions makes you sound like an executor rather than a strategic thinker and opens you up to misinterpretation.
+
+**Verbosity:** Communication is central to these roles, so talking too much is an easy habit to fall into. There’s a lot to cover in limited time and you need to adapt to the signal requested by the interviewer and provide only the most relevant context. See [this post](https://thebehavioral.substack.com/p/avoiding-too-much-detail-in-behavioral) for more.
+
+**Opening yourself to uncharitable interpretations:** Senior candidates face higher scrutiny, which means stories, or even individual actions, that might be acceptable for more junior candidates can raise red flags when told by someone at a senior level. This requires thinking defensively about how your stories might be interpreted. See the Thinking Defensively section below.
+
+## Story Selection: Beyond Pure Technical Impact
+
+At the senior level, your project stories need to demonstrate multifaceted leadership that spans the full spectrum of modern engineering work.
+
+**Choose projects with leadership complexity:** Look for initiatives that involved multiple teams, ambiguous requirements, and/or significant technical risk.
+
+**Demonstrate the full leadership spectrum:** Your stories should include evidence across four key dimensions:
+
+- **Technical leadership:** Architecture decisions, technology choices, technical debt management
+- **People leadership:** Mentoring, conflict resolution, team building, hiring and performance management
+- **Process and operational leadership:** Establishing engineering practices, incident response, capacity planning
+- **Strategic and business leadership:** Roadmap planning, stakeholder management, resource allocation
+
+<InDocAd />
+
+## Story Organization & Delivery: Managing Narrative Complexity
+
+Senior-level projects are inherently complex, often spanning months or years with multiple workstreams and stakeholders. Because the stories are longer, traditional STAR formatting breaks down when trying to capture this complexity.
+
+**Use the "Table of Contents" approach:** Begin with a brief overview of the major themes or phases you'll cover. For example: "This migration had three critical parts: the technical architecture decisions, managing organizational change across five teams, and handling the customer communication during the transition."
+
+**Front-load the impact:** Don't bury your results at the end. Senior interviewers may interrupt with detailed follow-ups, and you might never reach your conclusion. Include the results in the Situation section, with the business impact, then explain how you achieved it.
+
+**Prepare for interruptions:** Speaking of interruptions, senior behavioral interviews tend to be more conversational but also more impatient. Interviewers will dive deep into decision-making processes, ask about alternatives you considered, or explore specific aspects of team dynamics. Prepare modular story components you can expand or condense based on their interests. After you finish a follow up question, nudge the interviewer back to the next theme so you can continue to deliver signal on what you accomplished.
+
+**Add details that demonstrate scope:** Every detail should serve a purpose—to show technical complexity, organizational challenge, or strategic thinking. Mentioning "coordinating across 12 engineers in 4 time zones" signals scope. Describing "migrating 500M+ daily transactions with zero downtime" demonstrates both technical and business impact.
+
+**Leave out details that result in redundant takeaways:** The natural follow up to adding those kinds of details is leaving out ones that have the same takeaways you’ve established. If you’re discussing the third challenging technical situation on this project in gory detail, you are spending time harping on the same message—”I am technical”—when you could be using that time to establish other aspects of your career.
+
+**Know your audience:** Interviewers at this level can operate with less systematic structure and higher variance in interviewer approaches or you might be interviewed by XFN partners. Pay attention to what they're probing for and adjust your stories accordingly. A VP might care more about business impact and organizational alignment, a PM will ask about working with non-technical partners, while a Principal Engineer might dive deep into technical decision-making frameworks.
+
+**Observe and respond to your interviewer:** Watch for the listener’s engagement while you tell your story and adjust your level of detail accordingly. If they are frequently asking for elaboration, then provide that up front. If they haven’t written anything down for a while, consider whether you’re sharing relevant actions you’ve taken and consider moving on to another part of the story.
+
+## Thinking Defensively
+
+Behavioral interviewers make subjective judgments in 45-60 minutes, often reading between the lines and jumping to conclusions. Senior interviewers, having witnessed hiring mistakes, are naturally cautious—especially for leadership roles where a problematic hire can cascade across the organization.
+
+Even when your actions weren't "wrong," you can leave yourself open to uncharitable interpretations. Any gaps in your narrative get filled with assumptions that may not favor you.
+
+Read more about thinking defensively on [this post](https://thebehavioral.substack.com/p/thinking-defensively-in-behavioral) from Mastering Behavioral Interviews.
+
+### Common Problematic Framings
+
+**Passive ownership:** "I came to the sprint meeting and the manager assigned me this ticket..." signals weak ownership and junior-level thinking rather than business-focused initiative.
+
+**Lack of proactivity:** "The codebase lacked test coverage so it took me a while..." or "The executive didn't have visibility so it was under-resourced..." suggests you notice problems but don't drive solutions.
+
+**Letting ambiguity persist:** "The stakeholders had different opinions, so we scheduled several alignment meetings..." shows weak decision-making rather than driving through uncertainty.
+
+**One-way communication:** "The team documented the API changes in our wiki, but some teams still had integration issues..." treats communication as broadcast rather than ensuring understanding.
+
+### Identifying Weak Spots
+
+Use mock interviewers to spot story weaknesses you can't see yourself. Review your stories for potential negative signal by journaling about weaknesses. Be suspicious of follow-up questions—they often target perceived weaknesses.
+
+### Defensive Strategies
+
+The key is proactively addressing concerns and carefully framing your stories to avoid uncharitable interpretations that could derail your candidacy.
+
+**Elide problematic parts:** Instead of mentioning your manager assigned the ticket, say "I came out of the sprint meeting with this high-impact task..."
+
+**Proactively frame unavoidable issues:** Explain your rationale. For the stakeholder alignment example: "We strategized extensively and came in with a clear position, but executives were at odds about strategic direction. I realized this wasn't a product decision but a business question, so I prepared data on user engagement and revenue impact, then facilitated a decision-making session to resolve the strategic conflict with concrete evidence."
+
+**Acknowledge mistakes with learning:** "The team documented changes in our wiki, but some teams had integration issues. I realized we were hasty launching without coordination. I led changes to our process, having the tech lead add Change Management to planning docs for the future."
+
+_Interested in more behavioral content? Check out [Mastering Behavioral Interviews](https://thebehavioral.tech/) for a complete preparation guide._

--- a/apps/website/contents/behavioral-interview.md
+++ b/apps/website/contents/behavioral-interview.md
@@ -22,6 +22,8 @@ sidebar_label: Step-by-step how to prepare
 
 import InDocAd from './\_components/InDocAd';
 
+_The following page is a collaboration with [Austen McDonald](https://www.linkedin.com/in/austenmc/), former Senior Engineering Manager and Hiring Committee Chair at Meta, and author of [Mastering Behavioral Interviews](http://thebehavioral.tech/)._
+
 ## What are behavioral interviews
 
 Succeeding in an engineering career involves more than just technical skills. People skills become more important as an engineer becomes more senior. Senior engineers should have the ability to lead and influence, resolve conflicts, anticipate risks, plan the roadmap, and more.
@@ -42,6 +44,8 @@ From the company's perspective, the interview has two purposes:
 
 - Assess whether a candidate has a history of demonstrating the right behaviors that would make them successful at the company.
 - Assess the seniority of the candidate e.g. junior, senior, or staff.
+
+The importance of behavioral interviews is increasing as AI generates more code. Soft skills—how you work with people, and especially qualities like communication and willingness to learn—are pivotal as companies expect more from their engineers than simply implementation
 
 <InDocAd />
 
@@ -82,23 +86,59 @@ Here's an example of how the STAR format can be used to answer the question: "Te
 
 > "When our designer ended midterms, he came back with beautiful mockups that fit well into the wireframes. Our front-end developer implemented them with great care to detail. We ended up scoring top marks for the project and became a great team."
 
-### 2. Prepare your answers to commonly asked questions
+**Pro tip:** to show seniority and strong signal around growth, consider adding an additional R for Reflection. Finish your story with a look back at what you learned and took away. For more about this expanded version of STAR(R), check out [this post](https://thebehavioral.substack.com/p/using-the-carl-method-to-structure).
 
-The next natural step is to start preparing your answers for commonly asked behavioral interview questions. You may refer to [my list of 30 questions](./behavioral-interview-questions.md) which were collated across top tech companies for this.
+### 2. Organize your key stories
+
+Unlike preparing for a coding interview, drilling common questions is unlikely to be your best preparation strategy. Instead, you’ll likely find yourself leveraging a few key stories from larger projects in your career to answer most questions. It’s common for a project to have elements of addressing ambiguity and resolving conflict and communication, etc.
+
+Spend some time going through your past experiences, your resume, any performance reviews you may have access to, etc. and collect 3-5 projects that have high impact, high complexity, and high involvement by you.
+
+Consider projects like these:
+
+**High-Impact Projects:** Major launches, significant refactors, system migrations, new product features, architecture decisions that influenced multiple teams.
+
+**Challenging Situations:** Tight deadlines, technical failures, team or interpersonal conflicts, ambiguous requirements, projects where success was uncertain.
+
+**Leadership Moments:** Mentoring others, driving cross-team initiatives, representing your team externally, times when others looked to you for direction.
+
+**Learning Experiences:** Mistakes that led to growth, feedback that changed your approach, skills you developed under pressure, times when you had to completely rethink your approach.
+
+Construct a STAR(R) story for each project as an exercise in storytelling. Pay special attention to the Actions: these are the repeatable “behaviors” that the interview is named after. The company is not hiring you to do the same project you’ve done in the past but to engage in similar behaviors on their projects.
+
+### 3. Prepare answers to the Big Three Questions
+
+Despite our advice that preparing for specific questions has limited value, there are three questions that are very very common and it’s worth preparing in advance:
+
+- Tell me about yourself: this question opens almost any interview. See our advice at in [Preparing a self introduction](./behavioral-interview-questions.md) and a further dive [here](https://thebehavioral.substack.com/p/death-taxes-and-tmay).
+- Tell me about your favorite project/most impactful project/etc.: pick a project at the intersection of impact, scope, and your personal involvement.
+- Tell me about time when you resolved a conflict: this is the most common soft skill question. Check out a series of posts on choosing and structuring a response starting [here](https://thebehavioral.substack.com/p/conflict-stories-1-of-5-workplace).
 
 While most people might be inclined towards memorization, it's much better to pen down bullet points to each question and practice verbalizing them near to the interviews, so that your answers will come out more naturally.
 
-### 3. Prepare experiences to showcase fit to the company's culture / core values
+### 4. Practice other questions by yourself or with AI
+
+Even though trying to anticipate questions beyond the Big Three is challenging, you can get a lot of value out of practicing your story telling skills on sample questions. You may refer to [my list of 30 questions](./behavioral-interview-questions.md) which were collated across top tech companies for this. Also, going through this process will help you identify if there are significant gaps in your story catalog centered around specific signal areas. For example, perhaps you need more stories around past mistakes or .
+
+This is a natural place to use chatbots: prompt an LLM to ask you these questions and give you feedback on your responses. Also encourage the AI to ask you follow up questions.
+
+### 5. Prepare experiences to showcase fit to the company's culture / core values
 
 As aforementioned, most top tech companies use their company values to evaluate candidates in behavioral interviews. As such, you should do your research to find out what those values are and ensure you have prepared experiences that showcase fit.
 
-### 4. Try out mock behavioral interviews
+### 6. Try out mock behavioral interviews
 
 If you would like to practice behavioral interviews with professional interviewers from top tech companies, schedule one with [interviewing.io](https://iio.sh/r/DMCa). Interviewing.io boasts a large pool of interviewers from Facebook, Amazon, Apple, Google and Microsoft. I have used [interviewing.io](https://iio.sh/r/DMCa) both as an interviewer and interviewee and can guarantee a good experience with this platform.
 
-### 5. Use structured courses
+For some advice on how to maximize your experience with mock interviewers, check out [this post](https://thebehavioral.substack.com/p/getting-the-most-out-of-mock-behavioral).
 
-I don't really think one needs to attend a course on behavioral interviews, but your mileage may vary. I've seen candidates get rejected for failing the behavioral round even though they did super well on the coding and system design interviews. If you want to take a course on behavioral interviews, I'd recommend the following courses:
+### 7. Expand your knowledge with newsletters, books, and courses
+
+I've seen candidates get rejected for failing the behavioral round even though they did super well on the coding and system design interviews and if AI will be generating more and more code, behavioral interviews are getting more important—of course they’ve always been important for senior roles.
+
+Check out the free newsletter [Mastering Behavioral Interviews](https://thebehavioral.substack.com/) on Substack and the [accompanying book](https://thebehavioral.tech/).
+
+There are also courses available:
 
 - ["Behavioral Interviews" by Exponent](https://www.tryexponent.com/courses/behavioral?ref=techinterviewhandbook) - While Exponent also has courses on technical content, what really makes them stand out from the other interview preparation platform is their availability of content for non-software engineering roles such as Product Management and Product Marketing. Their behavioral interview course is a mix of videos (by the Exponent CEO himself!) and text, going through the most common questions and imparting you with techniques to help you ace the interview. To top it off, they also have an interview question bank for behavioral questions with responses from the platform's helpful community. While the subscription might be a little pricey for just the behavioral interviews content, they also offer quality technical content for [System Design](https://www.tryexponent.com/courses/system-design-interviews?ref=techinterviewhandbook), [Data Structures](https://www.tryexponent.com/courses/swe-practice?ref=techinterviewhandbook) and [Algorithms](https://www.tryexponent.com/courses/algorithms?ref=techinterviewhandbook). The convenience of a one-stop platform which covers all aspects of technical interview preparation is very enticing.
 - ["Grokking the Behavioral Interview" on Educative](https://www.educative.io/courses/grokking-the-behavioral-interview?aff=x23W) - As per other courses on Educative, this course is text-based and they believe that text-based courses are the more efficient than video courses. One thing that stands out about this course is that they teach you **patterns** for behavioral interviews, not just about memorizing questions and preparing answers.

--- a/apps/website/contents/self-introduction.md
+++ b/apps/website/contents/self-introduction.md
@@ -19,6 +19,8 @@ sidebar_label: Preparing a self introduction
 
 import InDocAd from './\_components/InDocAd';
 
+_The following page is a collaboration with [Austen McDonald](https://www.linkedin.com/in/austenmc/), former Senior Engineering Manager and Hiring Committee Chair at Meta, and author of [Mastering Behavioral Interviews](http://thebehavioral.tech/)._
+
 "Tell me about yourself" or "give me a quick introduction of your profile" is almost always the first question encountered in your software engineer interviews. This guide teaches you how to maximize this chance to impress the interviewer by crafting the perfect self introduction.
 
 Interviewers want to work with candidates they like. Leave a good/deep impression and it will increase your chances of success. Most of us are not strangers to self introductions as we meet new people now and then and have to introduce ourselves every once in a while. However, self introductions in interviews are slightly different from real life - you need to tweak it to your advantage - tailor the self introduction to the role and company you are applying for! Your self introduction evolves as you grow and are at a different stage of your career.
@@ -51,6 +53,8 @@ Does this look familiar? It should be, because it is similar to your resume! You
 ### 2. KISS (Keep It Simple and Sweet)
 
 Tell them some highlights from your favorite/most impressive projects and including some numbers if they're impressive or challenges that you've overcome. Do not delve into the depths of how you reverse engineered a game and decrypted a packet to predict when to use your DKP on a drop. Tell them the executive summary: "I reverse engineered X game by decrypting Y packet to predict Z." If this catches their interest, they might ask further questions on their own.
+
+Avoid a history lesson. "I started coding when I was 13 years old, went to college at State U, then worked as an intern for BigCo, then out of college I got a front-end job at SmallCo, then moved to backend at Acme, ..." is not adding value to the listener. In the discussions of your past, include roles that were meaningful and have some takeaway. For example, instead of the history lesson, try "I’ve had roles across large and small companies as well as worked across the stack."
 
 ### 3. Why do they want you?​
 

--- a/apps/website/sidebars.js
+++ b/apps/website/sidebars.js
@@ -40,6 +40,7 @@ module.exports = {
         'behavioral-interview',
         'behavioral-interview-rubrics',
         'behavioral-interview-questions',
+        'behavioral-interview-senior-candidates',
         'self-introduction',
         'final-questions',
       ],


### PR DESCRIPTION
- Complete some missing pieces of the general behavioral sections and adjust framing to better fit what I’ve experienced in my coaching practice
    - Example: preparing general stories + targeting Big Three questions before jumping into 30 common questions
- Add content specifically for senior engineers
- Sprinkle links to Mastering Behavioral Interview newsletter content where deeper dives are useful

Tried to preserve the existing compact and accessible text, keeping the content focused on ICs, preserving existing collaborations and as much original text as possible.
