### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: '16'
           cache: yarn

--- a/.github/workflows/tsc.yml
+++ b/.github/workflows/tsc.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: '16'
           cache: yarn


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/setup-node` from `v3` to `v6` in `.github/workflows/tsc.yml`
- Updated `actions/setup-node` from `v3` to `v6` in `.github/workflows/lint.yml`
- Updated `actions/checkout` from `v3` to `v6` in `.github/workflows/tsc.yml`
- Updated `actions/checkout` from `v3` to `v6` in `.github/workflows/lint.yml`
