### PR TITLE
content: fix resume font size recommendation from 10 px to 10 pt

### DIFF
--- a/apps/website/contents/resume.md
+++ b/apps/website/contents/resume.md
@@ -69,7 +69,7 @@ They also offer resume examples/references from candidates who have received mul
 
 New fonts may convert letters into special characters which are not readable by the ATS. Fonts you should use - **Arial, Calibri, Garamond**.
 
-Ensure your font size remains readable for humans later on in the hiring process - use a minimum size of **10px** for readability.
+Ensure your font size remains readable for humans later on in the hiring process - use a minimum size of **10 pt** for readability.
 
 ### Add sections with standard headings and ordering
 


### PR DESCRIPTION
# Description

Fixes the recommended minimum font size in the chapter ["Writing your software engineer resume"](https://www.techinterviewhandbook.org/resume/).

# Context

Previously, the guide recommended a minimum of 10 px. Since resumes are supposed to be written in standard word processors like Microsoft Word and Google Docs, 10 px converts to roughly 7.5 pt, which is illegible. The standard minimum readability for resumes is 10 pt.

# Related Issue

Closes #728 