### PR TITLE
fix(resume): change font size recommendation from 10px to 10pt

### DIFF
--- a/apps/website/contents/resume.md
+++ b/apps/website/contents/resume.md
@@ -69,7 +69,7 @@ They also offer resume examples/references from candidates who have received mul
 
 New fonts may convert letters into special characters which are not readable by the ATS. Fonts you should use - **Arial, Calibri, Garamond**.
 
-Ensure your font size remains readable for humans later on in the hiring process - use a minimum size of **10px** for readability.
+Ensure your font size remains readable for humans later on in the hiring process - use a minimum size of **10pt** for readability.
 
 ### Add sections with standard headings and ordering
 


### PR DESCRIPTION
## Description

Standard word processors (Microsoft Word, Google Docs) measure font size in **points (pt)**, not pixels (px). Using pixels is misleading because 10px converts to approximately 7.5pt, which is significantly smaller than the standard readable minimum for resumes.

## Changes

- Updated the resume guide to recommend a minimum of **10pt** instead of 10px

## References

- [MIT CAPD Resume Checklist](https://capd.mit.edu/resources/resume-checklist/) recommends minimum 10pt

Fixes #728