### PR TITLE
docs: use 10 pt for resume font size guidance

### DIFF
--- a/apps/website/contents/resume.md
+++ b/apps/website/contents/resume.md
@@ -69,7 +69,7 @@ They also offer resume examples/references from candidates who have received mul
 
 New fonts may convert letters into special characters which are not readable by the ATS. Fonts you should use - **Arial, Calibri, Garamond**.
 
-Ensure your font size remains readable for humans later on in the hiring process - use a minimum size of **10px** for readability.
+Ensure your font size remains readable for humans later on in the hiring process - use a minimum size of **10 pt** for readability.
 
 ### Add sections with standard headings and ordering
 


### PR DESCRIPTION
## Summary
- update the resume guide to recommend a minimum font size of **10 pt** instead of **10px**
- align the wording with how Microsoft Word and Google Docs actually express font sizes

Closes #728

## Validation
- `git diff --check`
- reviewed the rendered content change in `apps/website/contents/resume.md`