### PR TITLE
fix: use server-side session for authorization in offers comments router

### DIFF
--- a/apps/portal/src/server/router/offers/offers-comments-router.ts
+++ b/apps/portal/src/server/router/offers/offers-comments-router.ts
@@ -102,9 +102,10 @@ export const offersCommentsRouter = createRouter()
       profileId: z.string(),
       replyingToId: z.string().optional(),
       token: z.string().optional(),
-      userId: z.string().optional(),
     }),
     async resolve({ ctx, input }) {
+      const userId = ctx.session?.user?.id;
+
       const profile = await ctx.prisma.offersProfile.findFirst({
         where: {
           id: input.profileId,
@@ -113,7 +114,7 @@ export const offersCommentsRouter = createRouter()
 
       const profileEditToken = profile?.editToken;
 
-      if (input.token === profileEditToken || input.userId) {
+      if (input.token === profileEditToken || userId) {
         const createdReply = await ctx.prisma.offersReply.create({
           data: {
             message: input.message,
@@ -140,12 +141,12 @@ export const offersCommentsRouter = createRouter()
           });
         }
 
-        if (input.userId) {
+        if (userId) {
           await ctx.prisma.offersReply.update({
             data: {
               user: {
                 connect: {
-                  id: input.userId,
+                  id: userId,
                 },
               },
             },
@@ -193,11 +194,12 @@ export const offersCommentsRouter = createRouter()
       id: z.string(),
       message: z.string(),
       profileId: z.string(),
-      // Have to pass in either userID or token for validation
+      // Have to pass in either token for OP validation
       token: z.string().optional(),
-      userId: z.string().optional(),
     }),
     async resolve({ ctx, input }) {
+      const userId = ctx.session?.user?.id;
+
       const messageToUpdate = await ctx.prisma.offersReply.findFirst({
         where: {
           id: input.id,
@@ -212,10 +214,9 @@ export const offersCommentsRouter = createRouter()
       const profileEditToken = profile?.editToken;
 
       // To validate user editing, OP or correct user
-      // TODO: improve validation process
       if (
         profileEditToken === input.token ||
-        messageToUpdate?.userId === input.userId
+        (userId && messageToUpdate?.userId === userId)
       ) {
         const updated = await ctx.prisma.offersReply.update({
           data: {
@@ -277,11 +278,12 @@ export const offersCommentsRouter = createRouter()
     input: z.object({
       id: z.string(),
       profileId: z.string(),
-      // Have to pass in either userID or token for validation
+      // Have to pass in either token for OP validation
       token: z.string().optional(),
-      userId: z.string().optional(),
     }),
     async resolve({ ctx, input }) {
+      const userId = ctx.session?.user?.id;
+
       const messageToDelete = await ctx.prisma.offersReply.findFirst({
         where: {
           id: input.id,
@@ -296,10 +298,9 @@ export const offersCommentsRouter = createRouter()
       const profileEditToken = profile?.editToken;
 
       // To validate user editing, OP or correct user
-      // TODO: improve validation process
       if (
         profileEditToken === input.token ||
-        messageToDelete?.userId === input.userId
+        (userId && messageToDelete?.userId === userId)
       ) {
         await ctx.prisma.offersReply.delete({
           where: {


### PR DESCRIPTION
## Summary

The offers comments router in `apps/portal/src/server/router/offers/offers-comments-router.ts` accepts a client-supplied `userId` parameter for authorization decisions. This introduces broken access control vulnerabilities (CWE-862) across the create, update, and delete comment endpoints.

## Vulnerability Details

**Affected endpoints:** `comments.create`, `comments.update`, `comments.delete`

Three related issues exist in the current code:

1. **Comment creation authorization bypass:** The create handler checks `input.token === profileEditToken || input.userId`. Since `input.userId` is any truthy string supplied by the client, any unauthenticated user can create comments by passing an arbitrary `userId` — no valid session or token is required.

2. **Editing other users' comments (IDOR):** The update handler checks `messageToUpdate?.userId === input.userId`. An attacker who knows (or guesses) a victim's user ID can edit their comments by supplying it in the request.

3. **Deleting other users' comments (IDOR):** The delete handler has the same pattern — an attacker can delete any user's comment by supplying the victim's user ID.

**Preconditions:** Network access to the application. No authentication is needed to exploit the create bypass. For update/delete, the attacker needs to know a valid user ID (which may be exposed in comment responses).

## Fix

This PR removes the client-supplied `userId` from the input schema of all three endpoints and replaces it with the server-side session user ID (`ctx.session?.user?.id`). This ensures:

- **Create:** Only authenticated users (with a valid session) or users with the profile edit token can create comments.
- **Update/Delete:** The ownership check compares the comment's `userId` against the authenticated session user, not a client-supplied value. An additional null check (`userId &&`) prevents unauthenticated users from matching against comments with no owner.

## Testing

- Verified the diff is minimal and scoped to the single affected file (13 insertions, 12 deletions).
- Confirmed that the `userId` field is fully removed from all three input schemas, eliminating the attack surface.
- Confirmed that `ctx.session?.user?.id` is the standard pattern used elsewhere in this codebase for obtaining the authenticated user.
- Verified the fix preserves the existing token-based authorization path for profile owners.

## Changes

- `offers-comments-router.ts`: Remove `userId` from input schemas; derive user identity from `ctx.session?.user?.id`; add null guard on userId comparison for update/delete.