### PR TITLE
fix: verify session ownership for offers comment mutations (CWE-862)

### DIFF
--- a/apps/portal/src/server/router/offers/offers-comments-router.ts
+++ b/apps/portal/src/server/router/offers/offers-comments-router.ts
@@ -113,7 +113,11 @@ export const offersCommentsRouter = createRouter()
 
       const profileEditToken = profile?.editToken;
 
-      if (input.token === profileEditToken || input.userId) {
+      // Verify that the userId matches the authenticated session user
+      const sessionUserId = ctx.session?.user?.id;
+      const isValidUserId = input.userId && input.userId === sessionUserId;
+
+      if (input.token === profileEditToken || isValidUserId) {
         const createdReply = await ctx.prisma.offersReply.create({
           data: {
             message: input.message,
@@ -140,7 +144,7 @@ export const offersCommentsRouter = createRouter()
           });
         }
 
-        if (input.userId) {
+        if (isValidUserId) {
           await ctx.prisma.offersReply.update({
             data: {
               user: {
@@ -211,11 +215,13 @@ export const offersCommentsRouter = createRouter()
 
       const profileEditToken = profile?.editToken;
 
+      // Verify that the userId matches the authenticated session user
+      const sessionUserId = ctx.session?.user?.id;
+
       // To validate user editing, OP or correct user
-      // TODO: improve validation process
       if (
         profileEditToken === input.token ||
-        messageToUpdate?.userId === input.userId
+        (input.userId && input.userId === sessionUserId && messageToUpdate?.userId === input.userId)
       ) {
         const updated = await ctx.prisma.offersReply.update({
           data: {
@@ -295,11 +301,13 @@ export const offersCommentsRouter = createRouter()
 
       const profileEditToken = profile?.editToken;
 
+      // Verify that the userId matches the authenticated session user
+      const sessionUserId = ctx.session?.user?.id;
+
       // To validate user editing, OP or correct user
-      // TODO: improve validation process
       if (
         profileEditToken === input.token ||
-        messageToDelete?.userId === input.userId
+        (input.userId && input.userId === sessionUserId && messageToDelete?.userId === input.userId)
       ) {
         await ctx.prisma.offersReply.delete({
           where: {


### PR DESCRIPTION
## Summary

The offers comment router in `apps/portal/src/server/router/offers/offers-comments-router.ts` accepts a client-supplied `userId` in the request input for creating, updating, and deleting comments — but never verifies that this `userId` actually belongs to the authenticated session user.

This means any authenticated user can impersonate another user by simply passing their `userId` in the request body, allowing them to:
- **Create** comments attributed to other users
- **Update** other users' comments
- **Delete** other users' comments

The vulnerability exists because the authorization checks only verify that `input.userId` is truthy (non-empty), not that it matches the session. For the update and delete operations, the code compares `input.userId` against the stored comment's `userId`, but since both values are attacker-controlled or predictable, this provides no real protection.

## Fix

For all three mutation endpoints (create, update, delete), the fix validates that `input.userId` matches `ctx.session?.user?.id` before authorizing the operation:

- **Create**: Changed `input.userId` (truthy check) → `input.userId && input.userId === sessionUserId`
- **Update**: Changed `messageToUpdate?.userId === input.userId` → `input.userId && input.userId === sessionUserId && messageToUpdate?.userId === input.userId`
- **Delete**: Same pattern as update

This ensures the caller can only act on behalf of their own authenticated session. The existing token-based authorization path (for anonymous profile editors using `editToken`) is unchanged.

## Testing

- Verified the fix compiles and the diff is minimal (1 file, 14 insertions, 6 deletions).
- Confirmed that the three affected code paths (create reply, update reply, delete reply) all now gate on session ownership.
- Confirmed the `editToken`-based authorization path remains functional and unaffected.

## Security Analysis

The vulnerability is straightforward to exploit: an attacker only needs to be authenticated (or in some code paths, not even authenticated) and supply an arbitrary `userId` in the tRPC mutation input. There are no server-side checks preventing this — the `userId` from the request is trusted directly.

The `TODO: improve validation process` comments in the original code suggest this gap was known but unaddressed. This fix resolves it by comparing the supplied `userId` against the server-side session, which is the standard approach for preventing broken authorization in session-based applications.