### PR TITLE
fix: add ownership check to resume delete mutation

### DIFF
--- a/apps/portal/src/server/router/resumes/resumes-resume-user-router.ts
+++ b/apps/portal/src/server/router/resumes/resumes-resume-user-router.ts
@@ -441,7 +441,18 @@ export const resumesResumeUserRouter = createProtectedRouter()
       id: z.string(),
     }),
     async resolve({ ctx, input }) {
+      const userId = ctx.session.user.id;
       const { id } = input;
+
+      const resume = await ctx.prisma.resumesResume.findUnique({
+        where: {
+          id,
+        },
+      });
+
+      if (resume?.userId !== userId) {
+        throw new Error('Unauthorized: you can only delete your own resumes');
+      }
 
       return await ctx.prisma.resumesResume.delete({
         where: {


### PR DESCRIPTION
## Summary

The `delete` mutation in `resumes-resume-user-router.ts` is missing an authorization check. The route uses `createProtectedRouter()`, which verifies that the user is **authenticated**, but does not verify that the user **owns** the resume being deleted. Any authenticated user can delete any other user's resume by supplying its ID.

This is a **Broken Object Level Authorization (BOLA)** vulnerability, classified as [CWE-862: Missing Authorization](https://cwe.mitre.org/data/definitions/862.html).

## Affected Code

**File:** `apps/portal/src/server/router/resumes/resumes-resume-user-router.ts`  
**Mutation:** `delete` (around line 438)

The `input.id` is passed directly to `prisma.resumesResume.delete()` without checking that `resume.userId` matches the session user.

## How It Is Exploitable

1. Attacker creates a normal authenticated account.
2. Attacker obtains or guesses a resume ID (these are typically UUIDs but could be enumerated or leaked).
3. Attacker calls the `delete` mutation with that ID.
4. The resume is permanently deleted regardless of who owns it.

The only precondition is a valid authenticated session.

## Fix

Before deleting, the fix fetches the resume and checks that its `userId` matches `ctx.session.user.id`. If the user does not own the resume (or it does not exist), the mutation throws an error and the delete is not performed.

```typescript
const resume = await ctx.prisma.resumesResume.findUnique({
  where: { id },
});

if (resume?.userId !== userId) {
  throw new Error("Unauthorized: you can only delete your own resumes");
}
```

This is consistent with how other mutations in the codebase guard write operations.

## Testing

- Verified the fix compiles with no type errors against the existing Prisma schema.
- Confirmed the diff is minimal (1 file changed, 11 insertions) and does not affect any other functionality.
- Reviewed that `resumesResume` has a `userId` field in the Prisma schema, confirming the ownership check is valid.

## Note

A similar pattern exists in `resumes-comments-user-router.ts` for comment deletion, which may warrant a separate review.
